### PR TITLE
uart: Fix UART config issue and baud divisor calculation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ impl DelayNs for DummyDelay {
     }
 }
 
+
 #[entry]
 fn main() -> ! {
 
@@ -31,15 +32,15 @@ fn main() -> ! {
     unsafe {
         uart_controller.init(Config {
             baud_rate: 115200,
-            word_length: 8,
+            word_length: aspeed_ddk::uart::WordLength::Eight as u8,
             parity: aspeed_ddk::uart::Parity::None,
             stop_bits: aspeed_ddk::uart::StopBits::One,
             clock: 24_000_000,
         });
     }
 
-    uart_controller.write_all(b"Hello, world!\n").unwrap();
-    uart_controller.write_all(b"aspeed_ddk!\n").unwrap();
+    uart_controller.write_all(b"\r\nHello, world!\r\n").unwrap();
+    uart_controller.write_all(b"aspeed_ddk!\r\n").unwrap();
 
     // Initialize the peripherals here if needed
     loop {}

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -44,6 +44,14 @@ pub enum StopBits {
     Two,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum WordLength {
+    Five,
+    Six,
+    Seven,
+    Eight,
+}
+
 pub struct UartController<'a> {
     uart: Uart,
     delay: &'a mut dyn DelayNs,
@@ -51,16 +59,16 @@ pub struct UartController<'a> {
 
 impl UartController<'_> {
     /// # Safety
-    /// 
+    ///
     /// This function is unsafe because it directly interacts with hardware registers.
     ///
     /// Initializes the UART controller with the given configuration.
     /// # Arguments
-    /// 
+    ///
     /// * `config` - The configuration settings for the UART controller.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// let config = Config::default();
     /// unsafe {
@@ -69,7 +77,7 @@ impl UartController<'_> {
     /// ```
     pub unsafe fn init(&self, config: Config) {
         // Calculate baud divisor
-        let baud_divisor = (config.clock / (16 * config.baud_rate)) as u16; // Assuming 48 MHz clock
+        let baud_divisor = ((config.clock / 13) / (16 * config.baud_rate)) as u16; // Assuming 48 MHz clock
 
         // Enable DLAB to access divisor latch registers
         self.uart.uartlcr().write(|w| w.dlab().set_bit());


### PR DESCRIPTION
- Added a `WordLength` enum for clearer UART word length configuration.
- Replace incorrect word_length 8 with WordLength::Eight (CLS=0b11)
- Changed UART output to use CRLF line endings.
- Fixed baud divisor calculation in `UartController::init`.