### PR TITLE
feat : Add async-io feature and embedded-io-async dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal 1.0.0-alpha.1",
  "embedded-io",
+ "embedded-io-async",
  "fugit",
  "hex-literal",
  "panic-halt",
@@ -218,6 +219,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
+dependencies = [
+ "embedded-io",
+]
 
 [[package]]
 name = "embedded-storage"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ test-rsa = []
 test-ecdsa = []
 test-hmac = []
 test-hash = []
+async-io = ["embedded-io-async"]
 
 [dependencies]
 ast1060-pac = { git = "https://github.com/rusty1968/ast1060-pac.git", features = ["rt"] }
@@ -34,4 +35,8 @@ hex-literal = "0.4"
 cortex-m = { version = "0.7.5" }
 cortex-m-rt = { version = "0.6.5", features = ["device"] }
 panic-halt = "1.0.0"
+
+[dependencies.embedded-io-async]
+version = "0.6"
+optional = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,7 @@ pub mod rsa;
 pub mod syscon;
 pub mod tests;
 pub mod uart;
+#[cfg(feature = "async-io")]
+pub mod uart_async;
+
 pub mod watchdog;

--- a/src/uart_async.rs
+++ b/src/uart_async.rs
@@ -1,0 +1,55 @@
+// Licensed under the Apache-2.0 license
+
+use ast1060_pac::Uart;
+
+use crate::uart::UartController;
+
+use core::future::poll_fn;
+use core::task::{Context, Poll};
+use embedded_io_async::{Read, Write};
+
+/// Async implementation of embedded_io_async::Read for UartController.
+///
+/// Reads bytes asynchronously from the UART receiver buffer.
+/// Waits until data is available before reading each byte.
+impl embedded_io_async::Read for UartController<'_> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let mut count = 0;
+        for byte in buf.iter_mut() {
+            poll_fn(|cx| {
+                if self.is_data_ready() {
+                    *byte = self.read_rbr();
+                    Poll::Ready(Ok(()))
+                } else {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            })
+            .await?;
+            count += 1;
+        }
+        Ok(count)
+    }
+}
+
+/// Async implementation of embedded_io_async::Write for UartController.
+///
+/// Writes bytes asynchronously to the UART transmit holding register.
+/// Waits until the transmitter is ready before sending each byte.
+impl embedded_io_async::Write for UartController<'_> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        for &byte in buf {
+            poll_fn(|cx| {
+                if self.is_thr_empty() {
+                    self.write_thr(byte);
+                    Poll::Ready(Ok(()))
+                } else {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            })
+            .await?;
+        }
+        Ok(buf.len())
+    }
+}


### PR DESCRIPTION
We may need a stop-gap bare metal environment  using embassy-rs to serve as a test bed for integration with middleware. Embassy s an embedded async Rust framework. 


- Added the async-io feature to Cargo.toml, enabling async support for UART and other modules. 
- Added embedded-io-async as an optional dependency, activated by the async-io feature. Updated code to use feature gating for async implementations.

I am looking for volunteers who would like to add async feature to the crate for UART.  This is a minimalist implementation which can server as a starting point.