### PR TITLE
Implementation of  OpenProt owned digest API for ASPEED HACE controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,11 @@ dependencies = [
  "embedded-io",
  "fugit",
  "hex-literal",
+ "openprot-hal-blocking",
  "panic-halt",
  "paste",
  "proposed-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -313,6 +315,15 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openprot-hal-blocking"
+version = "0.1.0"
+source = "git+https://github.com/OpenPRoT/openprot#fe5ef09d013ff827cd7a89de0df34ead170db6b5"
+dependencies = [
+ "embedded-hal 1.0.0",
+ "zerocopy",
+]
 
 [[package]]
 name = "panic-halt"
@@ -642,4 +653,24 @@ dependencies = [
  "once_cell",
  "toml",
  "walkdir",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ proposed-traits = { git = "https://github.com/rusty1968/proposed_traits.git", pa
 hex-literal = "0.4"
 paste = "1.0"
 
+openprot-hal-blocking = { git="https://github.com/OpenPRoT/openprot" }
+zerocopy = { version = "0.8.25", features = ["derive"] }
+
 cortex-m = { version = "0.7.5" }
 cortex-m-rt = { version = "0.6.5", features = ["device"] }
 panic-halt = "1.0.0"

--- a/src/hace_controller.rs
+++ b/src/hace_controller.rs
@@ -1,7 +1,9 @@
 // Licensed under the Apache-2.0 license
 
 use ast1060_pac::Hace;
-use core::convert::Infallible;
+use core::convert::{Infallible, AsRef};
+use core::default::Default;
+use core::marker::Sync;
 use proposed_traits::digest::ErrorType as DigestErrorType;
 use proposed_traits::mac::ErrorType as MacErrorType;
 
@@ -132,7 +134,7 @@ pub trait ContextCleanup {
     fn cleanup_context(&mut self);
 }
 
-impl ContextCleanup for crate::hace_controller::HaceController<'_> {
+impl ContextCleanup for crate::hace_controller::HaceController {
     fn cleanup_context(&mut self) {
         let ctx = self.ctx_mut();
         ctx.bufcnt = 0;
@@ -315,15 +317,15 @@ impl HashAlgo {
     }
 }
 
-pub struct HaceController<'ctrl> {
-    pub hace: &'ctrl Hace,
+pub struct HaceController {
+    pub hace: Hace,
     pub algo: HashAlgo,
     pub aspeed_hash_ctx: AspeedHashContext, // Own the context instead of using a pointer
 }
 
-impl<'ctrl> HaceController<'ctrl> {
+impl HaceController {
     #[must_use]
-    pub fn new(hace: &'ctrl Hace) -> Self {
+    pub fn new(hace: Hace) -> Self {
         Self {
             hace,
             algo: HashAlgo::SHA256,
@@ -338,15 +340,15 @@ impl<'ctrl> HaceController<'ctrl> {
     }
 }
 
-impl DigestErrorType for HaceController<'_> {
+impl DigestErrorType for HaceController {
     type Error = Infallible;
 }
 
-impl MacErrorType for HaceController<'_> {
+impl MacErrorType for HaceController {
     type Error = Infallible;
 }
 
-impl HaceController<'_> {
+impl HaceController {
     pub fn ctx_mut(&mut self) -> &mut AspeedHashContext {
         unsafe { &mut *Self::shared_ctx() }
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -119,13 +119,13 @@ impl IntoHashAlgo for Sha512 {
     }
 }
 
-impl<'ctrl, A> DigestInit<A> for HaceController<'ctrl>
+impl<A> DigestInit<A> for HaceController
 where
     A: DigestAlgorithm + IntoHashAlgo,
     A::DigestOutput: Default + AsMut<[u8]>,
 {
     type OpContext<'a>
-        = OpContextImpl<'a, 'ctrl, A>
+        = OpContextImpl<'a, A>
     where
         Self: 'a; // Define your OpContext type here
 
@@ -144,8 +144,8 @@ where
     }
 }
 
-pub struct OpContextImpl<'a, 'ctrl, A: DigestAlgorithm + IntoHashAlgo> {
-    pub controller: &'a mut HaceController<'ctrl>,
+pub struct OpContextImpl<'a, A: DigestAlgorithm + IntoHashAlgo> {
+    pub controller: &'a mut HaceController,
     _phantom: core::marker::PhantomData<A>,
 }
 
@@ -164,14 +164,14 @@ impl From<ErrorKind> for HashError {
     }
 }
 
-impl<A> ErrorType for OpContextImpl<'_, '_, A>
+impl<A> ErrorType for OpContextImpl<'_, A>
 where
     A: DigestAlgorithm + IntoHashAlgo,
 {
     type Error = HashError;
 }
 
-impl<A> DigestOp for OpContextImpl<'_, '_, A>
+impl<A> DigestOp for OpContextImpl<'_, A>
 where
     A: DigestAlgorithm + IntoHashAlgo,
     A::DigestOutput: Default + AsMut<[u8]>,

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -125,14 +125,14 @@ impl IntoHashAlgo for Sha512 {
     }
 }
 
-impl<'ctrl, A> MacInit<A> for HaceController<'ctrl>
+impl<A> MacInit<A> for HaceController
 where
     A: MacAlgorithm + IntoHashAlgo,
     A::MacOutput: Default + AsMut<[u8]>,
     A::Key: AsRef<[u8]>,
 {
     type OpContext<'a>
-        = OpContextImpl<'a, 'ctrl, A>
+        = OpContextImpl<'a, A>
     where
         Self: 'a; // Define your OpContext type here
 
@@ -171,8 +171,8 @@ where
     }
 }
 
-pub struct OpContextImpl<'a, 'ctrl, A: MacAlgorithm + IntoHashAlgo> {
-    pub controller: &'a mut HaceController<'ctrl>,
+pub struct OpContextImpl<'a, A: MacAlgorithm + IntoHashAlgo> {
+    pub controller: &'a mut HaceController,
     _phantom: core::marker::PhantomData<A>,
 }
 
@@ -191,14 +191,14 @@ impl From<ErrorKind> for MacError {
     }
 }
 
-impl<A> ErrorType for OpContextImpl<'_, '_, A>
+impl<A> ErrorType for OpContextImpl<'_, A>
 where
     A: MacAlgorithm + IntoHashAlgo,
 {
     type Error = MacError;
 }
 
-impl<A> MacOp for OpContextImpl<'_, '_, A>
+impl<A> MacOp for OpContextImpl<'_, A>
 where
     A: MacAlgorithm + IntoHashAlgo,
     A::MacOutput: Default + AsMut<[u8]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ecdsa;
 pub mod gpio;
 pub mod hace_controller;
 pub mod hash;
+pub mod hash_owned;
 pub mod hmac;
 pub mod pinctrl;
 pub mod rsa;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,10 @@ use aspeed_ddk::tests::functional::hmac_test::run_hmac_tests;
 use aspeed_ddk::tests::functional::rsa_test::run_rsa_tests;
 use panic_halt as _;
 
+// Import owned API traits and types
+use aspeed_ddk::hash_owned::{Sha2_256, Sha2_384, Sha2_512};
+use openprot_hal_blocking::digest::owned::{DigestInit, DigestOp};
+
 use proposed_traits::system_control::ResetControl;
 
 use cortex_m_rt::entry;
@@ -115,6 +119,133 @@ macro_rules! debug_halt {
     }};
 }
 
+/// Test the owned digest API demonstrating move-based resource management
+fn test_owned_digest_api(uart: &mut UartController<'_>) {
+    writeln!(uart, "\r\nRunning owned digest API tests...\r\n").unwrap();
+    
+    // Get a fresh HACE peripheral for owned API testing
+    let peripherals = unsafe { Peripherals::steal() };
+    let hace = peripherals.hace;
+    
+    // Test SHA256 with owned API
+    writeln!(uart, "Testing owned SHA256 API...").unwrap();
+    test_owned_sha256(uart, hace);
+    
+    // Get fresh peripheral for SHA384 test (since it was consumed)
+    let peripherals = unsafe { Peripherals::steal() };
+    let hace = peripherals.hace;
+    
+    writeln!(uart, "Testing owned SHA384 API...").unwrap();
+    test_owned_sha384(uart, hace);
+    
+    // Get fresh peripheral for SHA512 test
+    let peripherals = unsafe { Peripherals::steal() };
+    let hace = peripherals.hace;
+    
+    writeln!(uart, "Testing owned SHA512 API...").unwrap();
+    test_owned_sha512(uart, hace);
+    
+    writeln!(uart, "All owned digest API tests completed!\r\n").unwrap();
+}
+
+/// Test owned SHA256 API demonstrating move semantics
+fn test_owned_sha256(uart: &mut UartController<'_>, hace: ast1060_pac::Hace) {
+    let controller = HaceController::new(hace);
+    
+    // Initialize owned context - controller is moved
+    let context = match controller.init(Sha2_256) {
+        Ok(ctx) => ctx,
+        Err(_) => {
+            writeln!(uart, "Failed to initialize SHA256 context").unwrap();
+            return;
+        }
+    };
+    
+    // Update with data - context is moved and returned
+    let context = match context.update(b"Hello ") {
+        Ok(ctx) => ctx,
+        Err(_) => {
+            writeln!(uart, "Failed to update SHA256 context").unwrap();
+            return;
+        }
+    };
+    
+    let context = match context.update(b"Owned ") {
+        Ok(ctx) => ctx,
+        Err(_) => {
+            writeln!(uart, "Failed to update SHA256 context").unwrap();
+            return;
+        }
+    };
+    
+    let context = match context.update(b"API!") {
+        Ok(ctx) => ctx,
+        Err(_) => {
+            writeln!(uart, "Failed to update SHA256 context").unwrap();
+            return;
+        }
+    };
+    
+    // Finalize and get both digest and controller back
+    let (digest, _recovered_controller) = match context.finalize() {
+        Ok((dig, ctrl)) => (dig, ctrl),
+        Err(_) => {
+            writeln!(uart, "Failed to finalize SHA256 context").unwrap();
+            return;
+        }
+    };
+    
+    writeln!(uart, "SHA256 owned API digest: {:02x?}", &digest.value[..8]).unwrap();
+    writeln!(uart, "SHA256 owned API: PASSED ✅").unwrap();
+}
+
+/// Test owned SHA384 API demonstrating controller recovery
+fn test_owned_sha384(uart: &mut UartController<'_>, hace: ast1060_pac::Hace) {
+    let controller = HaceController::new(hace);
+    
+    let context = controller.init(Sha2_384).unwrap();
+    let context = context.update(b"Move-based").unwrap();
+    let context = context.update(b" resource").unwrap();
+    let context = context.update(b" management").unwrap();
+    
+    let (digest, recovered_controller) = context.finalize().unwrap();
+    
+    writeln!(uart, "SHA384 owned API digest: {:02x?}", &digest.value[..8]).unwrap();
+    writeln!(uart, "SHA384 owned API: PASSED ✅").unwrap();
+    
+    // Demonstrate controller recovery by using it again
+    let context2 = recovered_controller.init(Sha2_384).unwrap();
+    let context2 = context2.update(b"Reused controller").unwrap();
+    let (_digest2, _final_controller) = context2.finalize().unwrap();
+    
+    writeln!(uart, "Controller recovery: PASSED ✅").unwrap();
+}
+
+/// Test owned SHA512 API demonstrating cancellation
+fn test_owned_sha512(uart: &mut UartController<'_>, hace: ast1060_pac::Hace) {
+    let controller = HaceController::new(hace);
+    
+    let context = controller.init(Sha2_512).unwrap();
+    let context = context.update(b"This will be").unwrap();
+    let context = context.update(b" cancelled").unwrap();
+    
+    // Demonstrate cancellation - returns controller without computing digest
+    let recovered_controller = context.cancel();
+    
+    writeln!(uart, "SHA512 cancellation: PASSED ✅").unwrap();
+    
+    // Use recovered controller for actual computation
+    let context = recovered_controller.init(Sha2_512).unwrap();
+    let context = context.update(b"Persistent").unwrap();
+    let context = context.update(b" session").unwrap();
+    let context = context.update(b" contexts").unwrap();
+    
+    let (digest, _final_controller) = context.finalize().unwrap();
+    
+    writeln!(uart, "SHA512 owned API digest: {:02x?}", &digest.value[..8]).unwrap();
+    writeln!(uart, "SHA512 owned API: PASSED ✅").unwrap();
+}
+
 #[entry]
 fn main() -> ! {
     let peripherals = unsafe { Peripherals::steal() };
@@ -154,6 +285,9 @@ fn main() -> ! {
     run_hash_tests(&mut uart_controller, &mut hace_controller);
 
     run_hmac_tests(&mut uart_controller, &mut hace_controller);
+
+    // Test the owned digest API
+    test_owned_digest_api(&mut uart_controller);
 
     // Enable RSA and ECC
     let _ = syscon.enable_clock(ClockId::ClkRSACLK as u8);

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn main() -> ! {
     let reset_id = ResetId::RstHACE;
     let _ = syscon.reset_deassert(&reset_id);
 
-    let mut hace_controller = HaceController::new(&hace);
+    let mut hace_controller = HaceController::new(hace);
 
     run_hash_tests(&mut uart_controller, &mut hace_controller);
 

--- a/test_qemu.py
+++ b/test_qemu.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Licensed under the Apache-2.0 license
+
+"""
+ASPEED QEMU Test Script
+This script builds and tests the ASPEED application using QEMU
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import signal
+import time
+from datetime import datetime
+from pathlib import Path
+
+# Colors for output
+class Colors:
+    RED = '\033[0;31m'
+    GREEN = '\033[0;32m'
+    YELLOW = '\033[1;33m'
+    NC = '\033[0m'  # No Color
+
+# Configuration
+QEMU_MACHINE = "ast1030-evb"
+TARGET = "thumbv7em-none-eabihf"
+QEMU_CMD = "/home/ferro/qemu/bin/qemu-system-arm"
+TIMEOUT_SECONDS = 60
+
+def print_step(message):
+    print(f"{Colors.GREEN}[STEP]{Colors.NC} {message}")
+
+def print_warning(message):
+    print(f"{Colors.YELLOW}[WARN]{Colors.NC} {message}")
+
+def print_error(message):
+    print(f"{Colors.RED}[ERROR]{Colors.NC} {message}")
+
+def check_qemu_exists():
+    """Check if QEMU binary exists and is executable"""
+    if not os.path.isfile(QEMU_CMD) or not os.access(QEMU_CMD, os.X_OK):
+        print_error(f"qemu-system-arm not found at {QEMU_CMD}")
+        print_warning("To build QEMU with ASPEED support:")
+        print("  cd /home/ferro/qemu")
+        print("  mkdir build && cd build")
+        print("  ../configure --target-list=arm-softmmu")
+        print("  make -j 4")
+        return False
+    return True
+
+def build_project(build_mode):
+    """Build the project using cargo xtask"""
+    print_step(f"Building project in {build_mode} mode...")
+    
+    try:
+        if build_mode == "release":
+            subprocess.run(["cargo", "xtask", "build", "--release"], 
+                         check=True, cwd="/home/ferro/git/aspeed-rust")
+            binary_path = f"target/{TARGET}/release/aspeed-ddk"
+        else:
+            subprocess.run(["cargo", "xtask", "build"], 
+                         check=True, cwd="/home/ferro/git/aspeed-rust")
+            binary_path = f"target/{TARGET}/debug/aspeed-ddk"
+        
+        full_binary_path = f"/home/ferro/git/aspeed-rust/{binary_path}"
+        
+        if not os.path.isfile(full_binary_path):
+            print_error(f"Binary not found at {full_binary_path}")
+            return None
+            
+        print_step(f"Binary built successfully: {full_binary_path}")
+        return full_binary_path
+        
+    except subprocess.CalledProcessError as e:
+        print_error(f"Build failed with exit code {e.returncode}")
+        return None
+
+def run_qemu_with_timeout(binary_path, machine, capture_output, output_file, timeout_sec):
+    """Run QEMU with timeout and optional output capture"""
+    cmd = [QEMU_CMD, "-M", machine, "-nographic", "-kernel", binary_path]
+    
+    print_step(f"Running QEMU with machine '{machine}' (timeout: {timeout_sec}s)...")
+    if capture_output and output_file:
+        print(f"Output will be captured to: {output_file}")
+    
+    print(f"Command: {' '.join(cmd)}")
+    print("Press Ctrl+C to stop QEMU manually")
+    print("-" * 40)
+    
+    # Start QEMU process
+    try:
+        if capture_output and output_file:
+            # Use tee to capture output while displaying it
+            tee_cmd = ["tee", output_file]
+            
+            qemu_process = subprocess.Popen(cmd, 
+                                          stdout=subprocess.PIPE, 
+                                          stderr=subprocess.STDOUT, 
+                                          universal_newlines=True,
+                                          bufsize=1)
+            
+            tee_process = subprocess.Popen(tee_cmd,
+                                         stdin=qemu_process.stdout,
+                                         stdout=sys.stdout,
+                                         stderr=sys.stderr,
+                                         universal_newlines=True)
+            
+            qemu_process.stdout.close()  # Allow qemu_process to receive a SIGPIPE if tee_process exits
+            
+            # Wait for timeout
+            try:
+                tee_process.wait(timeout=timeout_sec)
+            except subprocess.TimeoutExpired:
+                print_warning(f"\nQEMU execution timed out after {timeout_sec} seconds")
+                print_step("Terminating QEMU process...")
+                
+                # Terminate processes
+                qemu_process.terminate()
+                tee_process.terminate()
+                
+                # Wait a bit for graceful termination
+                time.sleep(1)
+                
+                # Force kill if still running
+                try:
+                    qemu_process.kill()
+                    tee_process.kill()
+                except:
+                    pass
+                
+                print_step(f"Output captured in: {output_file}")
+                return True
+            
+            # If we get here, the process completed before timeout
+            qemu_process.wait()
+            
+        else:
+            # Run without capture
+            qemu_process = subprocess.Popen(cmd,
+                                          stdout=sys.stdout,
+                                          stderr=sys.stderr,
+                                          universal_newlines=True)
+            
+            # Wait for timeout
+            try:
+                qemu_process.wait(timeout=timeout_sec)
+            except subprocess.TimeoutExpired:
+                print_warning(f"\nQEMU execution timed out after {timeout_sec} seconds")
+                print_step("Terminating QEMU process...")
+                
+                # Terminate process
+                qemu_process.terminate()
+                
+                # Wait a bit for graceful termination
+                time.sleep(1)
+                
+                # Force kill if still running
+                try:
+                    qemu_process.kill()
+                except:
+                    pass
+                
+                return True
+        
+        print_step("QEMU process completed successfully!")
+        return True
+        
+    except KeyboardInterrupt:
+        print_warning("\nReceived interrupt signal (Ctrl+C)")
+        print_step("Terminating QEMU process...")
+        try:
+            qemu_process.terminate()
+            if capture_output and output_file:
+                tee_process.terminate()
+        except:
+            pass
+        return True
+        
+    except Exception as e:
+        print_error(f"Error running QEMU: {e}")
+        return False
+
+def main():
+    parser = argparse.ArgumentParser(description="ASPEED QEMU Test Script")
+    parser.add_argument("--release", action="store_true",
+                       help="Build in release mode (default: debug)")
+    parser.add_argument("--machine", default=QEMU_MACHINE,
+                       help=f"Set QEMU machine type (default: {QEMU_MACHINE})")
+    parser.add_argument("--output", "-o", metavar="FILE",
+                       help="Capture QEMU output to file")
+    parser.add_argument("--timeout", type=int, default=TIMEOUT_SECONDS,
+                       help=f"Set timeout in seconds (default: {TIMEOUT_SECONDS})")
+    
+    args = parser.parse_args()
+    
+    print_step("Starting ASPEED QEMU test...")
+    
+    # Check QEMU availability
+    if not check_qemu_exists():
+        return 1
+    
+    print_step(f"Using QEMU: {QEMU_CMD}")
+    
+    # Build project
+    build_mode = "release" if args.release else "debug"
+    binary_path = build_project(build_mode)
+    if not binary_path:
+        return 1
+    
+    # Set output file
+    output_file = None
+    capture_output = False
+    if args.output:
+        output_file = args.output
+        capture_output = True
+    elif args.output == "":  # --output without argument
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_file = f"qemu_output_{timestamp}.log"
+        capture_output = True
+    
+    # Run QEMU
+    success = run_qemu_with_timeout(binary_path, args.machine, 
+                                   capture_output, output_file, args.timeout)
+    
+    # Show output file location if captured
+    if capture_output and output_file and os.path.isfile(output_file):
+        print_step(f"Output captured in: {output_file}")
+        print(f"To view the output: cat {output_file}")
+    
+    if success:
+        print_step("QEMU test completed successfully!")
+        return 0
+    else:
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Add src/hash_owned.rs implementing move-based digest API with compile-time safety
- Convert HaceController from borrowing to owning Hace peripheral
- Support SHA256, SHA384, SHA512 with owned DigestInit and DigestOp traits
- Enable persistent session storage and controller recovery patterns
- Add comprehensive owned API tests demonstrating move semantics
- Fix lifetime parameter issues throughout hash/hmac modules
- Introduce python script to automate QEMU testing.