### PR TITLE
[feat] I2c refactor to  enable system level resource management 

### DIFF
--- a/src/i2c/i2c_controller.rs
+++ b/src/i2c/i2c_controller.rs
@@ -2,13 +2,24 @@
 
 use crate::common::{Logger, NoOpLogger};
 use crate::i2c::common::I2cConfig;
+use core::result::Result;
 use embedded_hal::i2c::{Operation, SevenBitAddress};
+use proposed_traits::system_control::{ClockControl, ResetControl};
 
 pub trait HardwareInterface {
     type Error: embedded_hal::i2c::Error + core::fmt::Debug;
 
+    fn init_with_system_control<
+        S: ResetControl<ResetId = crate::syscon::ResetId>
+            + ClockControl<ClockId = crate::syscon::ClockId>,
+    >(
+        &mut self,
+        system_control: &mut S,
+        config: &mut I2cConfig,
+    ) -> Result<(), Self::Error>;
+
     // Methods return hardware-specific errors
-    fn init(&mut self, config: &mut I2cConfig);
+    fn init(&mut self, config: &mut I2cConfig) -> Result<(), Self::Error>;
     fn configure_timing(&mut self, config: &mut I2cConfig);
     fn enable_interrupts(&mut self, mask: u32);
     fn clear_interrupts(&mut self, mask: u32);

--- a/src/tests/functional/i2c_test.rs
+++ b/src/tests/functional/i2c_test.rs
@@ -122,7 +122,7 @@ pub fn test_i2c_master(uart: &mut UartController<'_>) {
     };
 
     pinctrl::Pinctrl::apply_pinctrl_group(pinctrl::PINCTRL_I2C1);
-    i2c1.hardware.init(&mut i2c1.config);
+    let _ = i2c1.hardware.init(&mut i2c1.config);
 
     let addr = 0x2e; //device ADT7490
     let mut buf = [0x4e];


### PR DESCRIPTION
I2C Initialization Improvement
The original `init()` function had architectural limitations that prevented integration with system control task architectures:


1. **Mixed Concerns**: Global I2C system setup + peripheral controller setup combined in one function.
2. **Silent Failures**: No error propagation from reset/clock operations.
3. **Direct SCU register access** makes it hard to integrate in an environment where we have a dedicated system control dirver like Hubris.

