### PR TITLE
Add the destination address to the buffer

### DIFF
--- a/src/i2c_core/constants.rs
+++ b/src/i2c_core/constants.rs
@@ -67,6 +67,10 @@ pub const AST_I2CC_SLAVE_EN: u32 = 1 << 1;
 pub const AST_I2CC_MASTER_EN: u32 = 1 << 0;
 /// Disable multi-master capability
 pub const AST_I2CC_MULTI_MASTER_DIS: u32 = 1 << 15;
+/// Enable save address byte into buffer for Slave Packet mode receive command (I2CC00 bit 20)
+/// Per AST1060 datasheet section 13.3.1, when this bit is set, the slave address byte
+/// is saved into the receive buffer in slave packet mode.
+pub const AST_I2CC_SLAVE_PKT_SAVE_ADDR: u32 = 1 << 20;
 
 // Master Command Register (I2CM18) bit definitions
 // Reference: ast1060_i2c.rs:58-69

--- a/src/i2c_core/slave.rs
+++ b/src/i2c_core/slave.rs
@@ -133,10 +133,14 @@ impl Ast1060I2c<'_> {
         // Clear slave interrupts
         self.clear_slave_interrupts();
 
-        // Enable slave mode
+        // Enable slave mode and save address byte in packet mode (I2CC00 bit 20)
+        // This makes the hardware include the destination address byte in the receive buffer
+        // which is required for MCTP-over-SMBus (DSP0237) packet format.
         self.regs()
             .i2cc00()
-            .modify(|_, w| w.enbl_slave_fn().set_bit());
+            .modify(|r, w| unsafe {
+                w.bits(r.bits() | constants::AST_I2CC_SLAVE_EN | constants::AST_I2CC_SLAVE_PKT_SAVE_ADDR)
+            });
 
         // Configure slave mode
         let mut cmd = 0u32;


### PR DESCRIPTION
This activate packet address saving the destination byte into the inbound buffer. mctp-rs expects this to be present.

If this needs to be relocated into aspeed-ddk we can move it there.